### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+---
+language: python
+python: "2.7"
+
+cache: pip
+
+install:
+  - pip install ansible
+
+script:
+  - ansible-playbook --syntax-check -i inventories/localhost site.yml
+  - ansible-playbook --list-hosts -i inventories/localhost site.yml
+  - ansible-playbook --list-tags -i inventories/localhost site.yml
+  - ansible-playbook --list-tasks -i inventories/localhost site.yml
+
+notifications:
+  email: false


### PR DESCRIPTION
Travis CI now runs a basic ansible syntax check.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>