### PR TITLE
Add ansible-lint to travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ python: "2.7"
 cache: pip
 
 install:
-  - pip install ansible
+  - pip install ansible ansible-lint
 
 script:
   - ansible-playbook --syntax-check -i inventories/localhost site.yml
   - ansible-playbook --list-hosts -i inventories/localhost site.yml
   - ansible-playbook --list-tags -i inventories/localhost site.yml
   - ansible-playbook --list-tasks -i inventories/localhost site.yml
+  - ansible-lint site.yml
 
 notifications:
   email: false

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install extra packages
   package:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ extra_packages }}"
 
 - name: Allow password-less sudo for sudo group


### PR DESCRIPTION
[ansible-lint](https://github.com/willthames/ansible-lint) is a tool to
check ansible playbooks for best practices. All playbooks in site.yml
will be checked.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>