### PR TITLE
Move ansible-lint to `before_script` in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ cache: pip
 install:
   - pip install ansible ansible-lint
 
+before_script:
+  - ansible-lint site.yml
+
 script:
   - ansible-playbook --syntax-check -i inventories/localhost site.yml
   - ansible-playbook --list-hosts -i inventories/localhost site.yml
   - ansible-playbook --list-tags -i inventories/localhost site.yml
   - ansible-playbook --list-tasks -i inventories/localhost site.yml
-  - ansible-lint site.yml
 
 notifications:
   email: false


### PR DESCRIPTION
Having linters in `before_script` means that linting failures cause
builds to exit sooner and helps keep build logs clean.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>