### PR TITLE
Add znc hostgroup to inventories/localhost

### DIFF
--- a/inventories/localhost
+++ b/inventories/localhost
@@ -1,2 +1,5 @@
 [local]
 localhost              ansible_connection=local
+
+[znc:children]
+local


### PR DESCRIPTION
The localhost inventory needs the znc hostgroup so it can deploy znc.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>