### PR TITLE
Change SSH config from lineinfile to copy

### DIFF
--- a/roles/common/files/etc/ssh/sshd_config
+++ b/roles/common/files/etc/ssh/sshd_config
@@ -1,0 +1,28 @@
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+UsePrivilegeSeparation yes
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+SyslogFacility AUTH
+LogLevel INFO
+LoginGraceTime 120
+PermitRootLogin prohibit-password
+StrictModes yes
+RSAAuthentication yes
+PubkeyAuthentication yes
+IgnoreRhosts yes
+RhostsRSAAuthentication no
+HostbasedAuthentication no
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+PasswordAuthentication no
+X11Forwarding no
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -37,25 +37,13 @@
     mode: 0664
   with_items: "{{ system_users }}"
 
-- name: Disable SSH password authentication
-  lineinfile:
+- name: Add sshd_config
+  copy:
+    src: etc/ssh/sshd_config
     dest: /etc/ssh/sshd_config
-    regexp: 'PasswordAuthentication'
-    line: 'PasswordAuthentication no'
-  notify: Restart SSH
-
-- name: Disable SSH challenge response authentication
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: 'ChallengeResponseAuthentication'
-    line: 'ChallengeResponseAuthentication no'
-  notify: Restart SSH
-
-- name: Enable SSH pubkey authentication
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: 'PubkeyAuthentication'
-    line: 'PubkeyAuthentication yes'
+    owner: root
+    group: root
+    mode: 0644
   notify: Restart SSH
 
 - name: Enable OpenSSH in UFW


### PR DESCRIPTION
Previously, we used the lineinfile ansible module to configure sshd,
which was subpar. Now we are using the copy module to send what we want.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>